### PR TITLE
Granular check fix

### DIFF
--- a/lib/bridges/ain2.js
+++ b/lib/bridges/ain2.js
@@ -85,10 +85,8 @@ function delegate(method, _args) {
 
   var callPosition = metalogger.callposition();
 
-  if (!metalogger.logLevelAllowedGranular(method)) {
-    if (!metalogger.logLevelAllowed(method, _level)) {
-      return;
-    }
+  if (!metalogger.shouldLog(method, _level)) {
+    return;
   }
 
   var args = Array.prototype.slice.call(_args);

--- a/lib/bridges/log.js
+++ b/lib/bridges/log.js
@@ -26,14 +26,11 @@ exports = module.exports = function(level) {
 
 function delegate(method, _args) {
 
-  var logLevelAllowed           = require('../metalogger').logLevelAllowed
-    , logLevelAllowedGranular   = require('../metalogger').logLevelAllowedGranular
-    , callposition              = require('../metalogger').callposition();
-    
-  if (!logLevelAllowedGranular(method)) {
-    if (!logLevelAllowed(method, _level)) {
-      return;
-    }    
+  var shouldLog    = require('../metalogger').shouldLog
+    , callposition = require('../metalogger').callposition();
+
+  if (!shouldLog(method, _level)) {
+    return;
   }
 
   var args = Array.prototype.slice.call(_args);

--- a/lib/bridges/loggly.js
+++ b/lib/bridges/loggly.js
@@ -75,10 +75,8 @@ function delegate(method, _args) {
     , file
     , line;
 
-  if (!metalogger.logLevelAllowedGranular(method)) {
-    if (!metalogger.logLevelAllowed(method, _level)) {
-      return;
-    }
+  if (!metalogger.shouldLog(method, _level)) {
+    return;
   }
 
   var args = Array.prototype.slice.call(_args);

--- a/lib/bridges/npmlog.js
+++ b/lib/bridges/npmlog.js
@@ -35,14 +35,11 @@ exports = module.exports = function(level) {
 
 function delegate(method, _args) {
 
-  var logLevelAllowed           = require('../metalogger').logLevelAllowed
-    , logLevelAllowedGranular   = require('../metalogger').logLevelAllowedGranular
-    , callposition              = require('../metalogger').callposition();
-    
-  if (!logLevelAllowedGranular(method)) {
-    if (!logLevelAllowed(method, _level)) {
-      return;
-    }    
+  var shouldLog    = require('../metalogger').shouldLog
+    , callposition = require('../metalogger').callposition();
+
+  if (!shouldLog(method, _level)) {
+    return;
   }
 
   var args = Array.prototype.slice.call(_args);

--- a/lib/bridges/sumologic.js
+++ b/lib/bridges/sumologic.js
@@ -58,11 +58,10 @@ function delegate(method, _args) {
     , file
     , line;
 
-  if (!metalogger.logLevelAllowedGranular(method)) {
-    if (!metalogger.logLevelAllowed(method, _level)) {
-      return;
-    }
+  if (!metalogger.shouldLog(method, _level)) {
+    return;
   }
+
 
   var args = Array.prototype.slice.call(_args);
 

--- a/lib/bridges/util.js
+++ b/lib/bridges/util.js
@@ -22,14 +22,11 @@ exports = module.exports = function(level) {
 
 function delegate(method, _args) {
 
-  var logLevelAllowed           = require('../metalogger').logLevelAllowed
-    , logLevelAllowedGranular   = require('../metalogger').logLevelAllowedGranular
-    , callposition              = require('../metalogger').callposition();
-    
-  if (!logLevelAllowedGranular(method)) {
-    if (!logLevelAllowed(method, _level)) {
-      return;
-    }    
+  var shouldLog    = require('../metalogger').shouldLog
+    , callposition = require('../metalogger').callposition();
+
+  if (!shouldLog(method, _level)) {
+    return;
   }
 
   var args = Array.prototype.slice.call(_args);

--- a/lib/metalogger.js
+++ b/lib/metalogger.js
@@ -39,6 +39,8 @@ exports = module.exports = function(loggermodule, level) {
   return concreteLogger;
 };
 
+exports.logLevels               = logLevels;
+exports.shouldLog               = shouldLog;
 exports.logLevelAllowed         = logLevelAllowed;
 exports.logLevelAllowedGranular = logLevelAllowedGranular;
 exports.callposition            = callposition;

--- a/lib/metalogger.js
+++ b/lib/metalogger.js
@@ -103,27 +103,42 @@ var logLevelsObj = {
 function logLevels() {
   return Object.keys(logLevelsObj);
 }
-  
+
+/**
+ * Should I log?
+ *
+ * Use this instead of older pattern of granular check then global check.
+ */
+function shouldLog(testlevel, thresholdLevel) {
+  var allowed = logLevelAllowedGranular(testlevel);
+  if(allowed!==undefined) {
+    return allowed;
+  }
+
+  return logLevelAllowed(testlevel, thresholdLevel);
+}
+
 function logLevelAllowed(testlevel, thresholdLevel) {
   return logLevelsObj[testlevel] <= logLevelsObj[thresholdLevel];
 }
 
 /**
-* As opposed to logLevelAllowed() this one doesn't ake testlevel, since that
-* needs to be figured-out in-function.
+* As opposed to logLevelAllowed() this one doesn't take testlevel, since that
+* needs to be figured out in-function.
+*
+* We take care not to return an opinion if we don't know.
 */
 function logLevelAllowedGranular(testlevel) {
-  if (!_granularlevels) { return false; }
-  
-  var pos = callpositionObj();
-  var key = 'NODE_LOGGER_LEVEL_' + pos.filename.replace(/[\.\/]/gi, '_');
+  if(!_granularlevels) {
+    return undefined;
+  }
+  var pos = callpositionObj()
+    , key = 'NODE_LOGGER_LEVEL_' + pos.filename.replace(/[\.\/]/gi, '_');
 
   if (key in process.env && process.env[key]) {    
     var thresholdLevel = process.env[key];
     return logLevelsObj[testlevel] <= logLevelsObj[thresholdLevel];
-  }  
-
-  return false;
+  }
 }
 
 

--- a/test/basic.js
+++ b/test/basic.js
@@ -1,9 +1,14 @@
 var assert     = require('assert');
 
 describe('log level check: ', function() {
-  
-  var logLevelAllowed = require('../').logLevelAllowed; 
-  
+
+  var testable = require('../');
+  var levels = testable.logLevels();
+  var shouldLog = testable.shouldLog;
+  var logLevelAllowed = testable.logLevelAllowed;
+  var logLevelAllowedGranular = testable.logLevelAllowedGranular;
+
+
   it('lesser logger <debug> should not be allowed', function() {
     assert.equal(false, logLevelAllowed('debug', 'warning'));
   });
@@ -34,6 +39,16 @@ describe('log level check: ', function() {
 
   it('higher logger <emergency> should be allowed', function() {
     assert.equal(true, logLevelAllowed('emergency', 'warning'));
+  });
+
+  it('granular checking should be undefined if not enabled', function() {
+    assert.equal(undefined, logLevelAllowedGranular('warning'));
+  });
+
+  it('logging is not allowed if we do not know for sure that it is', function () {
+    levels.forEach(function(level) {
+      assert.equal(false, shouldLog(level));
+    });
   });
 
 


### PR DESCRIPTION
In cases where a per-file logging level disallowed logging, it was accidentally overridden by the global level, because of the way bridges were using logLevelAllowedGranular, and the fact that logLevelAllowedGranular did not distinguish between unspecified granular logging and disallowed logging.