### PR TITLE
Use new s3-streamlogger

### DIFF
--- a/lib/bridges/sumologic.js
+++ b/lib/bridges/sumologic.js
@@ -9,7 +9,7 @@ var bucketDetails = {
   access_key_id: '',
   secret_access_key: '',
   server_side_encryption: false,
-  name_format: '%Y-%m-%d-%H-%M-' + (process.env.NODE_ENV || 'development') + '-' + os.hostname() + '.log'
+  name_format: '%Y-%m-%d-%H-%M-%S-%L-' + (process.env.NODE_ENV || 'development') + '-' + os.hostname() + '.log'
 };
 
 var _level = 'debug';

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "loggly": "*",
     "npmlog": "*",
     "optional": "*",
-    "s3-streamlogger": "^0.2.1",
+    "s3-streamlogger": "^0.3.0",
     "yaml": "^0.2.3"
   },
   "devDependencies": {


### PR DESCRIPTION
In addition to millisecond granularity for filenames, this has an important fix that prevents epic numbers of writes after the first 20 seconds of the app's life.